### PR TITLE
Fix DBInterface transaction values and NULL binding

### DIFF
--- a/src/load.jl
+++ b/src/load.jl
@@ -118,8 +118,9 @@ end
 function DBInterface.transaction(f::Function, conn::Connection)
     DBInterface.execute(conn, "START TRANSACTION")
     try
-        f()
+        result = f()
         API.commit(conn.mysql)
+        return result
     catch
         API.rollback(conn.mysql)
         rethrow()

--- a/src/prepare.jl
+++ b/src/prepare.jl
@@ -317,6 +317,8 @@ function bind!(helper, binds, i, x::Missing)
     return
 end
 
+bind!(helper, binds, i, ::Nothing) = bind!(helper, binds, i, missing)
+
 function bind!(helper, binds, i, x::Real)
     if !helper.typeset
         inithelper!(helper, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -329,6 +329,15 @@ end
 DBInterface.execute(stmt, [missing, missing, missing, missing, missing, missing, missing, missing, missing, DateTime("2015-09-05T12:31:30"), missing, missing, missing, missing, missing])
 DBInterface.close!(stmt)
 
+DBInterface.execute(conn, "CREATE TABLE NullBindingTest (value INT NULL)")
+stmt = DBInterface.prepare(conn, "INSERT INTO NullBindingTest (value) VALUES (?)")
+DBInterface.execute(stmt, (nothing,))
+DBInterface.execute(stmt, (1,))
+DBInterface.execute(stmt, (missing,))
+DBInterface.close!(stmt)
+res = DBInterface.execute(conn, "SELECT value FROM NullBindingTest") |> columntable
+@test isequal(res.value, [missing, 1, missing])
+
 stmt = DBInterface.prepare(conn, "select * from Employee")
 res = DBInterface.execute(stmt) |> columntable
 DBInterface.close!(stmt)
@@ -511,7 +520,7 @@ ret = columntable(res)
 
         try
             # happy path
-            DBInterface.transaction(conn) do
+            result = DBInterface.transaction(conn) do
                 DBInterface.execute(conn, "INSERT INTO TransactionTest (a) VALUES (1)")
 
                 # we can see the result inside our transaction
@@ -521,7 +530,9 @@ ret = columntable(res)
                 # and can't see it outside our transaction
                 result = DBInterface.execute(conn2, "SELECT * FROM TransactionTest") |> Tables.columntable
                 @test isempty(result.a)
+                return 42
             end
+            @test result == 42
             result = DBInterface.execute(conn, "SELECT * FROM TransactionTest") |> Tables.columntable
             @test result.a == [1]
             result = DBInterface.execute(conn2, "SELECT * FROM TransactionTest") |> Tables.columntable


### PR DESCRIPTION
## Summary

- return the transaction closure value after a successful commit
- accept `nothing` as SQL `NULL`, matching the existing `missing` behavior
- add MySQL integration coverage for both cases

## Root cause

`DBInterface.transaction` discarded the closure result and returned the C API commit result. The prepared-statement binder had a null path only for `Missing`, so `Nothing` fell through to a `MethodError`.

## Scope

This addresses behaviors 2 and 3 from #238. The connection-level `DBInterface.execute(conn, sql, params)` form remains unsupported. Implementing it safely requires a statement-lifetime design because query cursors can outlive the call.

## Validation

- full test suite passed against `mysql:8`: 200 tests
- verified a prepared statement can bind `nothing`, a concrete value, and `missing` in sequence
- verified a committed transaction returns the closure value
- `git diff --check`

Refs #238

Co-authored by Codex